### PR TITLE
Set WiFlyDevice ssid / passphrase explicitly

### DIFF
--- a/WiFlyDevice.cpp
+++ b/WiFlyDevice.cpp
@@ -548,14 +548,17 @@ boolean WiFlyDevice::join(const char *ssid, const char *passphrase,
   sendCommand(F("set wlan "), true);
 
   if (isWPA) {
-    sendCommand(F("passphrase "), true);
+    sendCommand(F("phrase "), true);
   } else {
     sendCommand(F("key "), true);
   }
 
   sendCommand(passphrase);
 
-  return join(ssid);
+  sendCommand(F("set wlan ssid "), true);
+  sendCommand(ssid);
+
+  return join("");
 }
 
 


### PR DESCRIPTION
Per WiFly's user manual (updated 7/16/2010), it seems that the correct WLAN parameter for passphrases is actually just "phrase" (see section 5.11. WLAN Parameters).

Additionally, I had trouble connecting to my wireless network until I set the ssid explicitly via `set wlan ssid`. My SSID has both a space and a backslash in it (sigh), which was foolish in retrospect but hopefully these changes will make the library more robust overall.

Also note that I'm not tied to any of these changes, but noticed that they were necessary to allow my Arduino Uno to connect to my network via WiFly (after testing around a bit in command mode, as well.) Happy to receive suggestions / feedback about a better way to have made these changes.
