### PR TITLE
fixing stale setting after changes to WiFly Firmware

### DIFF
--- a/Libraries/WiFly_Shield/WiFlyDevice.cpp
+++ b/Libraries/WiFly_Shield/WiFlyDevice.cpp
@@ -646,7 +646,7 @@ boolean WiFlyDevice::configure(byte option, unsigned long value) {
     case ANTENNA_TYPE:
       enterCommandMode();
     
-      uart->print("set wlan ext_antenna ");
+      uart->print("set wlan extant ");
       uart->println(value);
 
       reboot();


### PR DESCRIPTION
Since the old pull request was left for so long it became stale, this sends the proper command to the WiFly since they changed the Firmware.
