### PR TITLE
Garbled output from Serial

### DIFF
--- a/Libraries/WiFly_Shield/SpiUart.cpp
+++ b/Libraries/WiFly_Shield/SpiUart.cpp
@@ -178,7 +178,7 @@ int SpiUartDevice::available() {
   // This alternative just checks if there's data but doesn't
   // return how many characters are in the buffer:
   // readRegister(LSR) & 0x01
-  delay(2);
+  //delay(2);
   return (readRegister(RXLVL));
 }
 


### PR DESCRIPTION
The delay seems to cause a buffer overrun leading to garbled output if
large output is received from the RN-131C. Removing the delay makes it
work fine.
