### PR TITLE
Add beginIP() method to use static ip

### DIFF
--- a/Libraries/WiFly_Shield/WiFlyDevice.cpp
+++ b/Libraries/WiFly_Shield/WiFlyDevice.cpp
@@ -284,10 +284,19 @@ void WiFlyDevice::begin(boolean adhocMode) {
   if (!bDifferentUart) SPIuart.begin();
   reboot(); // Reboot to get device into known state
   //requireFlowControl();
-  setConfiguration(adhocMode);
+  setConfiguration(adhocMode, NULL);
 }
 
-// TODO: Create a `begin()` that allows IP etc to be supplied.
+void WiFlyDevice::beginIP(const char *ip) {
+  /*
+   */
+  DEBUG_LOG(1, "Entered WiFlyDevice::beginIP()");
+
+  if (!bDifferentUart) SPIuart.begin();
+  reboot(); // Reboot to get device into known state
+  //requireFlowControl();
+  setConfiguration(false, ip);
+}
 
 
 
@@ -581,7 +590,7 @@ void WiFlyDevice::requireFlowControl() {
   reboot();
 }
 
-void WiFlyDevice::setConfiguration(boolean adhocMode) {
+void WiFlyDevice::setConfiguration(boolean adhocMode, const char *ip) {
   /*
    */
   enterCommandMode();
@@ -613,8 +622,14 @@ void WiFlyDevice::setConfiguration(boolean adhocMode) {
   if(!adhocMode)
   {
 	sendCommand(F("set wlan auth 4"));
-	
-	sendCommand(F("set ip dhcp 1"));
+
+        if (ip == NULL) {
+		sendCommand(F("set ip dhcp 1"));
+	} else {
+		sendCommand(F("set ip address "), true);
+		sendCommand(ip);
+		sendCommand(F("set ip dhcp 0"));
+	}
   } 
   else
   {

--- a/Libraries/WiFly_Shield/WiFlyDevice.h
+++ b/Libraries/WiFly_Shield/WiFlyDevice.h
@@ -12,6 +12,12 @@ class WiFlyDevice {
     void setUart(Stream* newUart);
     void begin();
     void begin(boolean adhocMode);
+
+    // begin using a static ip (without dhcp)
+    // you should provide the ip as a zero terminated string in the
+    // usual ip format ("192.168.100.42")
+    void beginIP(const char *ip);
+
 	  boolean createAdHocNetwork(const char *ssid);
 
     boolean join(const char *ssid);
@@ -68,7 +74,7 @@ class WiFlyDevice {
     void switchToCommandMode();
     void reboot();
     void requireFlowControl();
-    void setConfiguration(boolean adhocMode);
+    void setConfiguration(boolean adhocMode, const char *ip);
 	void setAdhocParams();
     boolean sendCommand(const char *command,
                         boolean isMultipartCommand, // Has default value


### PR DESCRIPTION
This pull requests adds support for static ip using the `set ip address <addr>` command. The WiFly API has been extended by a beginIP() method that expects the ip adress as it's only parameter as a a zero terminated string.

Instead of `WiFly.begin();` you can now use `WiFly.beginIP("<your-ip>");` to initialize the module. This will disable dhcp and use the provided ip adress instead.
