### PR TITLE
implement force wake

### DIFF
--- a/Libraries/WiFly_Shield/WiFlyDevice.cpp
+++ b/Libraries/WiFly_Shield/WiFlyDevice.cpp
@@ -224,6 +224,19 @@ void WiFlyDevice::sleepNow()
   exitCommandMode(); // Just in case, as the WiFly will sleep before reaching here.
 }
 
+void WiFlyDevice::wakeUp()
+{
+  if (!bDifferentUart)
+  {
+    //To wake up, set GPIO2 on the uart chip, which is connected to the
+    // FORCE WAKE pin on the WiFly
+    SPIuart.ioSetDirection(0b00000100);
+    SPIuart.ioSetState(0b00000000);
+    delay(1);
+    SPIuart.ioSetState(0b00000100);
+  }
+}
+
 
 
 void WiFlyDevice::skipRemainderOfResponse() {

--- a/Libraries/WiFly_Shield/WiFlyDevice.h
+++ b/Libraries/WiFly_Shield/WiFlyDevice.h
@@ -25,6 +25,7 @@ class WiFlyDevice {
                  boolean isWPA = true);
     boolean setWakeSleepTimers( int _wakeTimer, int _sleepTimer);
     void sleepNow();
+    void wakeUp();
                  
 
     boolean configure(byte option, unsigned long value);


### PR DESCRIPTION
This adds a `wakeup()` method to the WiFlyDevice that will cause the Wifly device to wake up after the `sleep()` method is called. Thanks to Cody from technical support for helping me figure this out.

Reopened https://github.com/sparkfun/WiFly-Shield/pull/39 from different branch