### PR TITLE
Fix problem with DEBUG_LEVEL > 0

### DIFF
--- a/Libraries/WiFly_Shield/Debug.h
+++ b/Libraries/WiFly_Shield/Debug.h
@@ -28,7 +28,7 @@
 #define DEBUG_LOG(level, message) \
   if (DEBUG_LEVEL >= level) {\
     Serial.print(F("DEBUG: "));\
-    Serial.println(F(message));\
+    Serial.println(message);\
   };
 
 #endif


### PR DESCRIPTION
The issue is that F only works with string literals. Thanks to this thread to help me figure out the problem: http://forum.arduino.cc/index.php?topic=116717.0

This seems to fix issue https://github.com/sparkfun/WiFly-Shield/issues/26