### PR TITLE
Deal with uart flow for baud rates greater than 9600.

### DIFF
--- a/Libraries/WiFly_Shield/WiFlyDevice.cpp
+++ b/Libraries/WiFly_Shield/WiFlyDevice.cpp
@@ -878,9 +878,13 @@ boolean WiFlyDevice::configure(byte option, unsigned long value) {
     case WIFLY_BAUD:
       // TODO: Use more of standard command sending method?
       enterCommandMode();
-      uart->print("set uart instant ");
-      uart->println(value);
-      delay(10); // If we don't have this here when we specify the
+      uart->print("set uart instant "); uart->println(value);
+
+      if (value > 9600) {
+        uart->println("set uart flow 1");
+      }
+
+      delay(1000); // If we don't have this here when we specify the
                  // baud as a number rather than a string it seems to
                  // fail. TODO: Find out why.
       SPIuart.begin(value);


### PR DESCRIPTION
Increase delay to 1000 was needed to have more successful connections.
Set uart flow type to work with baud rates greater than 9600.
